### PR TITLE
Refactor: separate server entry from app config

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -2,11 +2,11 @@
   "name": "server",
   "version": "1.0.0",
   "description": "",
-  "main": "app.js",
+  "main": "server.js",
   "scripts": {
-    "dev": "nodemon src/app.js",
+    "dev": "nodemon server.js",
     "build": "echo 'No build step for Express Server'",
-    "start": "node src/app.js"
+    "start": "node server.js"
   },
   "type": "commonjs",
   "dependencies": {

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,10 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
+const app = require('./src/app');
+
+const PORT = process.env.PORT || 5000;
+
+app.listen(PORT, () => {
+  console.log(`🚀 Server is running at http://localhost:${PORT}`);
+});

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,11 +1,9 @@
 const express = require("express");
 const cors = require("cors");
 
-require("dotenv").config();
-
 const app = express();
-const port = process.env.PORT || 3000;
 
 app.use(cors());
 app.get("/", (req, res) => res.send("Hello World!"));
-app.listen(port, () => console.log(`Example app listening on port ${port}!`));
+
+module.exports = app;


### PR DESCRIPTION
Moved `app.listen(...)` from `app.js` to a new `server.js` file to follow separation of concerns.

* `app.js`: defines and exports the Express app
* `server.js`: handles server startup

Improves structure, testability, and aligns with clean architecture.